### PR TITLE
To be publish NPM Package on First Release!!!

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,7 @@
         "padded-blocks": "off",
         "eol-last": "off",
         "no-unused-vars": "off",
-        "no-debugger": "off",
+        "no-debugger": "warn",
         "jest/valid-expect": [
             "error",
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 ### 1.0.0
-- Initial package using the same as Custom-Code-Editor in ApostropheCMS version 2.x.x
+- Initial package using the same as Custom-Code-Editor in ApostropheCMS version 2.x.x. First Release for ApostropheCMS version 3.x.x!

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An ApostropheCMS Custom Schema for your own custom-code-editor field.
 This schema uses Ace Editor library that you may found here [Ace Editor](https://ace.c9.io/)
 
 
-![Ace Editor Example](https://media.giphy.com/media/33F6GoBCalksXavQyN/giphy.gif)
+![Ace Editor Example](https://thumbs.gfycat.com/DecisiveThickGilamonster-size_restricted.gif)
 
 Falling in love with custom-code-editor module ? Send love ❤️ through Paypal here : <br>
 [Paypal.me/AminShazrin](https://paypal.me/AminShazrin?locale.x=en_US)
@@ -368,12 +368,12 @@ fields: {
 ### Search Bar
 Ace got it owns search bar. Simply hit `Ctrl + F` ! 
 
-![Search Function](https://media.giphy.com/media/dQlgFYEG6CbgoHWdHw/giphy.gif)
+![Search Function](https://thumbs.gfycat.com/HandsomeHopefulFallowdeer-size_restricted.gif)
 
 ### Save Selection
 Now this one is a new function ONLY for ApostropheCMS . If you hit `Ctrl + Shift + S` while selecting new code, it will replace an existing highlighted text previously when you change your mode. Don't believe me ? Check it out !
 
-![Save Feature](https://media.giphy.com/media/4EFt3QBgKu1NG5oz5a/giphy.gif)
+![Save Feature](https://thumbs.gfycat.com/ReliableHastyGrouper-size_restricted.gif)
 
 Wait ! Can I change save command ? Yup , you can. Add options like this :
 ```javascript
@@ -389,11 +389,9 @@ ace : {
 ```
 
 # Options Customizer
-Have you ever wonder that you are tired of testing options by restarting the app and adjust your options all over again ? 
+Have you ever wonder that you are tired of testing options by restarting the app and adjust your options all over again ? Here is Options Customizer that helps your editor options configuration better.
 
-Say no more ! Introducing new **Options Customizer** ! 
-
-![Options Customizer](https://media.giphy.com/media/JT1C49z4ghRFIvKPx1/giphy.gif)
+![Options Customizer](https://thumbs.gfycat.com/GrossShoddyIbisbill-size_restricted.gif)
 
 ### What does it do ?
 It brings you more features that you can't live without ! All options available for you to modify are now can be save to each logged in user or even you could copy all the desired options and paste it to your project level module ! Here are four core features for Options Customizer :
@@ -407,7 +405,7 @@ It brings you more features that you can't live without ! All options available 
 ## Copy Options
 You can copy your modified options and paste it on your project level module that will apply to all ! The copy features uses [Clipboard JS](https://clipboardjs.com/) to make it work. Below are the demonstration on how to use it :
 
-![Copy Options](https://media.giphy.com/media/MaNmlXtVdItUCXRR17/giphy.gif)
+![Copy Options](https://thumbs.gfycat.com/WarmheartedGlossyCow-size_restricted.gif)
 
 
 > NOTE : It only copies from modified changes, not on its entire options. If your module options are already configured, it will not copy your module options. Instead, it will copy all your changes options that you did on On/Off Toggle(s), Select Input(s) and Range Input(s).
@@ -415,7 +413,7 @@ You can copy your modified options and paste it on your project level module tha
 ## Undo Options
 You can undo your modified options to default settings. This will help you reset your changes to default options.
 
-![Undo Options](https://media.giphy.com/media/KbpWScHGzbpGfTAUTN/giphy.gif)
+![Undo Options](https://thumbs.gfycat.com/ElementaryGeneralCentipede-size_restricted.gif)
 
 
 > NOTE : This will not undo saved options to default setting. If you wish to reset from saved options, refer to section "Reset Options" below.
@@ -438,7 +436,7 @@ In MongoDB, you will see this data directly on `type : apostrophe-user` :
 ## Reset Options
 You can also reset all options. This will remove current saves options and change it to default module options settings. Let say you have follows save options demonstration above, you simply click `Reset` like example below :
 
-![Reset Options](https://media.giphy.com/media/RhYUiFiT5xoxM8cvIj/giphy.gif)
+![Reset Options](https://thumbs.gfycat.com/BlandWelloffAngwantibo-size_restricted.gif)
 
 > NOTE : This will only affect to current logged in user only. It will not removes any other users options.
 
@@ -460,7 +458,7 @@ module.exports = {
 
 > NOTE : If you wish to add more options, take a look at `aceTypes.js` in `node_modules/custom-code-editor/aceTypes.js` to see how it is done. And MAKE SURE you do it in an ARRAY like above example.
 
-## Remove Options
+## Disable Options Customizer
 You wish to remove options customizer ? You don't like it ? Don't worry, just set it to `enable : false` like this :
 ```js
 // In custom-code-editor-a3/index.js :

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Well, some other options will break apostrophe's UI and also against the rule of
 # Browser
 
 ### Browser Object
-How can I get this schema browser object for my `custom-code-editor` ?
+How can I get this schema browser object for my `custom-code-editor-a3` ?
 
 Simply you can find it on :
 

--- a/README.md
+++ b/README.md
@@ -445,13 +445,15 @@ What if you want to add your own help text, you could simply done it in project 
 ```js
 // In custom-code-editor-a3/index.js :
 module.exports = {
-    ace : {
-        optionsTypes : [
-            {
-                name : "highlightActiveLine",
-                help : "This will highlight active line cursor position"
-            }
-        ]
+    options: {
+        ace : {
+            optionsTypes : [
+                {
+                    name : "highlightActiveLine",
+                    help : "This will highlight active line cursor position"
+                }
+            ]
+        }
     }
 }
 ```
@@ -463,11 +465,13 @@ You wish to remove options customizer ? You don't like it ? Don't worry, just se
 ```js
 // In custom-code-editor-a3/index.js :
 module.exports = {
-    ace : {
-        config : {
-            optionsCustomizer : {
-                enable : false
-                // More configuration coming soon
+    options: {
+        ace : {
+            config : {
+                optionsCustomizer : {
+                    enable : false
+                    // More configuration coming soon
+                }
             }
         }
     }
@@ -540,6 +544,25 @@ apos.customCodeEditor.browser.editor.secondCode
 > Easy right ? Hell yeah it is ! :D
 
 # Advanced Configuration (Skip this if you comfortable with current feature)
+
+## Why I cannot switch other themes or other modes by scripting ?
+As I already mentioned in Push Asset section , by default we only push asset that are ONLY defined modes. It detect by your modes name and push. The rest of the modes will not be available in your browser. This is due to performance where Ace Editor contains more than 10 js files for all modes. If you really want to do by scripting that can switch themes or maybe other modes via scripting , you have to push ALL ACE's JS files in order to do that. Here is the code :
+
+```javascript
+// In modules/custom-code-editor-a3/index.js
+module.exports = {
+    options: {
+        ace : {
+            // all other ace options...
+            scripts : {
+                pushAllAce : true
+            }
+        }
+    }
+}
+```
+
+> NOTE : Beware that this push ALL ACE JS files including your own mode. Enable this only when you wanted to configure more ace on your own script. This might decrease performance and may require long time page loads.
 
 ## Add More Methods/Commands/Event Listener To Your Ace Editor
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Include in app.js:
 ```javascript
 // In app.js
   modules: {
-    'custom-code-editor': {},
+    'custom-code-editor-a3': {},
     // ... other modules
 }
 ```
@@ -29,13 +29,14 @@ Include in app.js:
 # Enable Code Editor Schema
 Simple :
 ```javascript
-addFields : [
-    {
-        type : 'custom-code-editor',
-        name : 'mycode',
-        label : 'Paste your code here'
+fields: {
+    add: {
+        code: {
+            type: 'custom-code-editor-a3',
+            label: 'First Code'
+        }
     }
-]
+}
 ```
 
 ### Widget.html Get `custom-code-editor` Value
@@ -64,39 +65,41 @@ or you can simply use `apos.log()` to see what's available on `custom-code-edito
 # Custom-Code-Editor Options Available
 
 ```javascript
-// in lib/modules/custom-code-editor/index.js
+// in modules/custom-code-editor-a3/index.js
 module.exports = {
-    ace : {
-        theme : 'tomorrow', // themes available : https://github.com/ajaxorg/ace/tree/master/lib/ace/theme (Case Sensitive)
-        defaultMode : 'javascript',
-        options : {
-            // All options available in : https://github.com/ajaxorg/ace/wiki/Configuring-Ace
-        },
-        modes : [
-            {
-                title : 'Javascript', // Title to Override Name
-                name : 'javascript', // Name of the mode (Case-Sensitive)
-                snippet : '// Content Start Here \n print(\"Hello World\") \n @code-here', // Default Value (String)
-                disableSnippet : true // Disable default snippet value when switching (OPTIONAL - Boolean)
-            }
-        ],
-        config: {
-            fontSize: 16, // Editor Font Size (Number or String)
-            editorHeight: 500, // Editor Height (Number or String)
-            dropdown: {
-                enable: true, // Enable it for switching modes button (Boolean)
-                height: 30, // Height Dropdown (Number or String)
-                borderRadius: 5, // Border Radius Dropdown (Number or String)
-                fontFamily: "Mont-Regular", // Font Family Dropdown (String)
-                backgroundColor : "Orange", // Background Color Dropdown (String)
-                textColor : "white", // Text Color Dropdown (String)
-                fontSize: 16, // Font Size Dropdown (Number or String)
-                position: {
-                    // All top , left , right , bottom dropdown position enable for configs
-                    bottom: 20,
-                    right: 20
-                },
-                arrowColor: "blue" // To change arrow color in dropdown (String)
+    options: {
+        ace : {
+            theme : 'tomorrow', // themes available : https://github.com/ajaxorg/ace/tree/master/lib/ace/theme (Case Sensitive)
+            defaultMode : 'javascript',
+            options : {
+                // All options available in : https://github.com/ajaxorg/ace/wiki/Configuring-Ace
+            },
+            modes : [
+                {
+                    title : 'Javascript', // Title to Override Name
+                    name : 'javascript', // Name of the mode (Case-Sensitive)
+                    snippet : '// Content Start Here \n print(\"Hello World\") \n @code-here', // Default Value (String)
+                    disableSnippet : true // Disable default snippet value when switching (OPTIONAL - Boolean)
+                }
+            ],
+            config: {
+                fontSize: 16, // Editor Font Size (Number or String)
+                editorHeight: 500, // Editor Height (Number or String)
+                dropdown: {
+                    enable: true, // Enable it for switching modes button (Boolean)
+                    height: 30, // Height Dropdown (Number or String)
+                    borderRadius: 5, // Border Radius Dropdown (Number or String)
+                    fontFamily: "Mont-Regular", // Font Family Dropdown (String)
+                    backgroundColor : "Orange", // Background Color Dropdown (String)
+                    textColor : "white", // Text Color Dropdown (String)
+                    fontSize: 16, // Font Size Dropdown (Number or String)
+                    position: {
+                        // All top , left , right , bottom dropdown position enable for configs
+                        bottom: 20,
+                        right: 20
+                    },
+                    arrowColor: "blue" // To change arrow color in dropdown (String)
+                }
             }
         }
     }
@@ -191,12 +194,14 @@ ace : {
 ### `@code-here` On Snippet
 What is that syntax for ? Well , whenever you change your mode on dropdown , existing codes on schema will replace automatically on new snippet on `@code-here`. Amazing right ? If you did not provide that syntax , your existing value on editor schema will be lost. Let's make a new override snippet and has our own `@code-here` on it :
 ```javascript
-      modes : [
-         {
+ace: {
+    modes : [
+        {
             name :'javascript',
             snippet : "// Content Start Here \n print(\"Hello World\") \n @code-here"
-         }
-      ],
+        }
+    ],
+}
 ```
 
 ### Title of Dropdown
@@ -319,37 +324,42 @@ ace : {
 Well, I know some of you don't want some specific editor to be in the same options to all custom-code-editor field type, right ? To make it backward compatibility, only some of the options can be overridden on your schema fields. Here is an example :
 
 ```javascript
-addFields : [
-    {
-        type : 'custom-code-editor',
-        name : 'mycode',
-        label : 'Paste your code here',
-        ace : {
-            defaultMode : "html"
-            config : {
-                // All config options here
+fields: {
+    add: {
+        code: {
+            type: 'custom-code-editor-a3',
+            label: 'Your code here',
+            ace: {
+                defaultMode: 'c_cpp',
+                config: {
+                    dropdown: {
+                        backgroundColor: '#040303',
+                        textColor: '#fffcf2',
+                        arrowColor: '#fffcf2'
+                    }
+                }
             }
         }
     }
-]
+}
 ```
-> Why `modes` and `theme` are not available to override ? This will against the rule optimizing push asset feature that only project level options module by your own defined modes and theme get push to browser. This is because Ace JS contains 10 and more JS files available to use. All `options` values must be configure in project level module `index.js` or directly on `app.js` in `modules: {}`
+> Why `modes` and `theme` are not available to override ? This will against the rule optimizing webpack feature that only project level options module by your own defined modes and theme get setup in the browser. All `options` values must be configure in project level module `index.js` or directly on `app.js` in `modules: {}`
 
 ### If you wish to disable some options, just set it to `null` on that property option. It will removed from your specific field option. For example :
 ```javascript
-addFields : [
-    {
-        type : 'custom-code-editor',
-        name : 'mycode',
-        label : 'Paste your code here',
-        ace : {
-            defaultMode : "html"
-            config : {
-                saveCommand : null
+fields: {
+    add: {
+        code: {
+            type: 'custom-code-editor-a3',
+            label: 'Your code here',
+            ace: {
+                config: {
+                    saveCommand: null,
+                }
             }
         }
     }
-]
+}
 ```
 
 > Warning ! If you did not set any config value, config will not be available on specific field. To use existing config, simply set it as empty object `config : {}`
@@ -378,7 +388,7 @@ ace : {
 }
 ```
 
-# New Custom-Code-Editor V3 (Options Customizer)
+# Options Customizer
 Have you ever wonder that you are tired of testing options by restarting the app and adjust your options all over again ? 
 
 Say no more ! Introducing new **Options Customizer** ! 
@@ -435,7 +445,7 @@ You can also reset all options. This will remove current saves options and chang
 ## Modify Options
 What if you want to add your own help text, you could simply done it in project level module like this : 
 ```js
-// In custom-code-editor/index.js :
+// In custom-code-editor-a3/index.js :
 module.exports = {
     ace : {
         optionsTypes : [
@@ -453,7 +463,7 @@ module.exports = {
 ## Remove Options
 You wish to remove options customizer ? You don't like it ? Don't worry, just set it to `enable : false` like this :
 ```js
-// In custom-code-editor/index.js :
+// In custom-code-editor-a3/index.js :
 module.exports = {
     ace : {
         config : {
@@ -480,295 +490,112 @@ Simply you can find it on :
 apos.customCodeEditor
 ```
 
+> I keep it similar `apos.customCodeEditor` object from ApostropheCMS version 2 so that you can copy paste your previous code from ApostropheCMS version 2 into ApostropheCMS version 3 easily without breaking change.
+
 ### Get Editor Browser Object
 How can I get from the one that defined in javascript browser at `var editor = ace.edit("editor")` as in Ace Editor Website has telling you about ?
 
 You can get it via browser scripting
 ```javascript
-apos.customCodeEditor.editor
+apos.customCodeEditor.browser.editor[your-field-name]
 ```
 
 By that , you can test anything on browser-side. For example you open on Chrome Developer Tools and enter :
 
 ```javascript
-apos.customCodeEditor.editor.session.getValue()
+apos.customCodeEditor.browser.editor[your-field-name].session.getValue()
 ```
 
 ### Get Multiple Editor Browser in Single Schema
 Oops ! How can I get specific editor browser object if I have two fields in a same schema ? I made a simple for you , let say you have this fields :
 
 ```javascript
-addFields : [
-    {
-        type : 'custom-code-editor',
-        name : 'mycode',
-        label : 'Paste Your First Code Here'
-    },
-    {
-        type : 'custom-code-editor',
-        name : 'mysecondcode',
-        label : 'Paste Your Second Code Here'
+fields: {
+    add: {
+        code: {
+            type: 'custom-code-editor-a3',
+            label: 'First Code'
+        },
+        secondCode: {
+                type: 'custom-code-editor-a3',
+                label: 'Second Code',
+                ace: {
+                    defaultMode: 'html',
+                    config: {
+                        saveCommand: null
+                    }
+                }
+        }
     }
-]
+}
 ```
 
 Next, simply get the `name` property to get specific schema in browser object : 
 ```javascript
 // First Editor
-apos.customCodeEditor.mycode.editor
+apos.customCodeEditor.browser.editor.code
 
 // Second Editor
-apos.customCodeEditor.mysecondcode.editor
+apos.customCodeEditor.browser.editor.secondCode
 ```
 
 > Easy right ? Hell yeah it is ! :D
 
 # Advanced Configuration (Skip this if you comfortable with current feature)
 
-## How To Insert My Stylesheets/Scripts Files ?
-I provide a simple object for you. Behold !
-
-### Stylesheets inside `public/css/<all css files>`
-```javascript
-ace : {
-    // All ace options
-},
-stylesheets : {
-    files : [
-        {
-            name : 'style.min', // This will get style.min.css
-            when : 'user'
-        },
-        {
-            name : 'parentFolder/style', // This will get style.css inside parentFolder
-            when : 'user'
-        }
-    ],
-    acceptFiles : ["css" , "sass" , "less" , "min.css"] // List of all accept files (Less , CSS and SASS are push by default)
-}
-```
-
-> Default `acceptFiles` : `css` , `sass` and `less`
-
-### Scripts inside `public/js/<all js files>`
-How about javascripts files ? Same as above example :
-
-```javascript
-ace : {
-    // All ace options
-},
-scripts : {
-    files : [
-        {
-            name : "custom", // This will get custom.js
-            when : "user"
-        }
-        {
-            name : 'parentFolder/myScript', // This will get myScript.js inside parentFolder
-            when : 'user'
-        }
-    ],
-    acceptFiles : ["js" , "min.js"] // List of all accept files (js and min.js are push by default)
-}
-```
-
-> Default `acceptFiles` : `js` and `min.js`.
-
-### Error on pushing file assets
-If you receive an error while pushing files assets to browser , please make sure your directory is in correct path without extension name and accept any files extension name by your own modified extension names. For example
-
-```javascript
-ace : {
-    // All ace options
-},
-scripts : {
-    files : [
-        {
-            // Or you can manually get custom.js inside parentFolder for specific js file
-            name : 'parentFolder/custom',
-            when : 'user'
-        },
-        {
-            // If got subfolder inside parentFolder
-            // Include it too
-            name : 'parentFolder/subFolder/custom', 
-            when : 'user'
-        },
-        {
-            name : 'index', // get index.js
-            when : 'user'
-        }
-    ]
-    acceptFiles : ["con.min.js"] // and other prefix extension file names available
-}
-```
-
-> NOTE : You don't have to include `'js/filedirectory'` or `'css/filedirectory'` in it. APOSTROPHECMS will push based on `self.pushAsset()` that you may found in [ApostropheCMS Push Asset Documentation](https://apostrophecms.org/docs/tutorials/getting-started/pushing-assets.html#configuring-stylesheets). Easy right ?
-
-
-### Why I cannot switch other themes or other modes by scripting ?
-As I already mentioned in Push Asset section , by default we only push asset that are ONLY defined modes. It detect by your modes name and push. The rest of the modes will not be available in your browser. This is due to performance where Ace Editor contains more than 10 js files for all modes. If you really want to do by scripting that can switch themes or maybe other modes via scripting , you have to push ALL ACE's JS files in order to do that. Here is the code :
-
-```javascript
-ace : {
-    // all ace options
-},
-scripts : {
-    pushAllAce : true
-}
-```
-
-> NOTE : Beware that this push ALL ACE JS files including your own mode. Enable this only when you wanted to configure more ace on your own script. This might decrease performance and may require long time page loads.
-
-
-# Add More Methods/Commands/Event Listener To Your Ace Editor
+## Add More Methods/Commands/Event Listener To Your Ace Editor
 
 Let say you want to add MORE commands that you already refer to [Ace Editor HOW TO](https://ace.c9.io/#nav=howto) or maybe add new events by yourself. First , let's create new js file to any name you like and push like this :
 
-```javascript
-// In custom-code-editor/index.js
-ace : {
-    // All ace options
-},
-scripts : {
-    files : [
-        {
-            name : 'custom', // will get /js/custom.js
-            when : 'user'
-        }
-    ]
-}
-```
+Inside `CustomCodeEditor.vue` :
+```vue
+// In modules/custom-code-editor-a3/ui/apos/components/CustomCodeEditor.vue
 
-And inside `custom.js` :
-```javascript
-// In custom-code-editor/public/js/custom.js
+<script>
+import customCodeEditor from 'custom-code-editor-a3/components/CustomCodeEditor.vue';
 
-apos.define('custom-code-editor', {
-    construct : function(self,options){
-        // create superPopulate to extend method
-        var superPopulate = self.populate;
-
-        // Get extension self object
-        var _this = self;
-
-        self.populate = function(object, name, $field, $el, field, callback){
-            // Locate the element on specific schema
-            var $fieldSet = apos.schemas.findFieldset($el, name);
-
-            // Get Editor
-            var $fieldInput = $fieldSet.find("[data-editor]").get(0);
-
-            // Init Editor
-            var editor = ace.edit($fieldInput);
-
+export default {
+    extends: customCodeEditor,
+    mixins: [customCodeEditor],
+    methods: {
+        afterInit(element) {
+            const editor = this.getEditor();
+            const self = this;
             // Add my own custom command
             editor.commands.addCommand({
                 name: 'myCommand',
-                bindKey: {win: 'Ctrl-M',  mac: 'Command-M'},
+                bindKey: {win: 'Ctrl-Shift-M',  mac: 'Command-Shift-M'},
                 exec: function(editor) {
-                    //...
+                    // Your commands code in here...
+                    return apos.notify('"' + self.field.name + '" field: ' + 'Ctrl + M/ Command + M is pressed!', {
+                        type: 'success',
+                        dismiss: true
+                    });
                 },
                 readOnly: true // false if this command should not apply in readOnly mode
             });
-
-            // ... your custom codes here
-
-            superPopulate(object, name , $field , $el , field , callback);
         }
     }
-})
+}
+</script>
 ```
 
-## Methods available
+## Extend Methods available
 These methods are available for you to use :
 
 
 | Method | Description |
 | --- | --- |
-| self.populate | Run once. If contain any bind event like clickEvent, mouseEvent and etc, it will execute normally like your javascript browser. Check documentation here : [self.populate](https://apostrophecms.org/docs/tutorials/intermediate/custom-schema-field-types.html#handling-user-input-the-browser-side)
-| self.convert | Run multiple times. It will trigger on submission. Check documentation here : [self.convert](https://apostrophecms.org/docs/tutorials/intermediate/custom-schema-field-types.html#what-39-s-going-on-in-this-code) |
-| _this | Just an example use of self . Because inside self.populate ,you cannot access self directly. You have to define it to a new variable. It returns all methods & options. |
-| self.has / _this.has | `self.has`/`_this.has` accepts object and a string of path. This works similar as `_.has` in lodash but to access nested object , you only can use dot notation in that string. It returns `boolean`. |
+| `this.beforeInit` | This extend method is initialised before editor is initialised but you can access `this.next` default value in it. |
+| `this.afterInit` | You can get `this.getEditor()` easily from this method so that you can add more commands anything to editor or you can add more functional programming to yourself :)
 
-
-### How to use `.has()` method ?
-
- How to use ? Simple :
-
-```javascript
-var myObject = {
-    nested : {
-        anotherNested : {
-            valueHere : true
-        }
-    }
-}
-
-// _this from extension object from self as shown example previously
-_this.has(myObject , "nested.anotherNested.valueHere");
-// Returns true
-
-_this.has(myObject , "nested.anotherNested.getValue"); 
-// Returns false since there is no getValue property inside anotherNested.getValue
-```
+## Methods available
+You can refer methods available for you to use in here:
+[Custom Code Editor Methods](https://ammein.github.io/custom-code-editor-a3/)
 
 #### Access all options available in `ace : {}` object
 Simple , you can access it via `self.ace` or `_this.ace`
 
 # Changelog
-### 3.1.7
-- Add `appearance : none` to checkbox to remove default checkbox CSS
-- Fix all codes by removing ES6 codes for minifying ApostropheCMS issue
-
-### 3.1.6
-- Build Passing
-- Add Unit Tests
-
-### 3.1.4
-- Adjust Readme to use proper configuration
-
-### 3.1.3
-- Using _.assign() to assign existing config options
-- Make merge options to be able on undefined some property that are will not be use or override.
-
-### 3.1.1
-- New feature, specific field customization available to override
-
-### 3.0.2
-- Fix README and typos.
-- Bug Fixes.
-
-### 3.0.1
-- Button Options display issue.
-
-### 3.0.0
-- New feature released, Options Customizer. Also change a bit stylish UI for user friendly.
-
-### 2.9.0
-- Update CSS to be cursor:pointer for better mouse hover experience
-
-### 2.8.6
-- Adjust README for better "first setup" experience to beginners.
-
-### 2.8.0
-- Push Asset Feature where push modes & themes that are only defined by User. The rest of the JS files will not be pushed. However , you can push All Ace JS files by configure option in scripts object. Refer the documentation.
-
-### 2.6.7
-- Fix every `name` of the modes into lowerCase(). This to avoid errors when developers setting it to capitalize words or any uppercase letters (tested). Also fix `getTitle` where `.capitalize()` helper is removed from that variable.
-
-### 2.6.5
-- Fix CSS where code folding can't be seen in your code editor. Now you can press it on gutter area.
-
-### 2.6.0
-- **NEW SAVE FEATURE ADDED !** Provide new shortcut key to save your own selection and switch dropdown with your own selection ! . Adjust README to have better documentation to all developers.
-
-- Fix if got empty modes when `clearModes : true` and should return text of `object[name].type`. This will not return empty text on dropdown when you have an existing value in schema.
-
-### 2.5.0
-
-- Fix default mode name should be show in dropdown if got `object[name]`. This will not be return empty text on dropdown.
-
-### 2.3.0
-
-- Adjust README and FIXED on existing dropdown `title` bug that would not update if open the schema again
+### 1.0.0
+- Initial package using the same as Custom-Code-Editor in ApostropheCMS version 2.x.x. First Release for ApostropheCMS version 3.x.x!

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ You can undo your modified options to default settings. This will help you reset
 ## Save Options
 You can also saves all your modified options. This will keep all your modified options apply to all custom-code-editor types !
 
-![Save Options](https://media.giphy.com/media/dsvKmzLZID4CyrRNWu/giphy.gif)
+![Save Options](https://thumbs.gfycat.com/KlutzyAridCavy-size_restricted.gif)
 
 In MongoDB, you will see this data directly on `type : apostrophe-user` :
 ```json

--- a/index.js
+++ b/index.js
@@ -10,6 +10,17 @@ module.exports = {
   },
   webpack: {
     extensions: {
+      aliasModules(options) {
+        return {
+          resolve: {
+            alias: {
+              'custom-code-editor-a3/components': path.resolve(__dirname, 'ui/apos/components'),
+              'custom-code-editor-a3/mixins': path.resolve(__dirname, 'ui/apos/mixins'),
+              'custom-code-editor-a3/style': path.resolve(__dirname, 'ui/src')
+            }
+          }
+        };
+      },
       aceBuildsFileLoader(options) {
         return {
           // Issue solve for ace-builds replace webpack loader options: https://stackoverflow.com/questions/69406829/how-to-set-outputpath-for-inline-file-loader-imports/69407756#69407756

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -13,7 +13,8 @@ module.exports = function(self) {
       _.extend(options.browser, {
         name: self.options.alias,
         action: self.action,
-        ace: self.ace
+        ace: self.ace,
+        mode: process.env.NODE_ENV || 'development'
       });
 
       _.extend(result, options);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy-page": "npm run jsdoc && gh-pages -d docs"
   },
   "dependencies": {
-    "ace-builds": "^1.11.0",
+    "ace-builds": "^1.11.2",
     "clipboard": "^2.0.11",
     "file-loader": "^6.2.0",
     "lodash": "^4.17.21",
@@ -32,7 +32,8 @@
   "license": "ISC",
   "devDependencies": {
     "apostrophe": "^3.28.1",
-    "eslint": "^8.23.1",
+    "clean-webpack-plugin": "^4.0.0",
+    "eslint": "^8.24.0",
     "eslint-config-punkave": "^2.1.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",

--- a/tests/test-asset.test.js
+++ b/tests/test-asset.test.js
@@ -229,14 +229,17 @@ describe('Custom Code Editor : Clear Modes and Push All Assets', function () {
 
   it('should generates all assets from custom-code-editor module from production modes', async function () {
     process.env.NODE_ENV = 'production';
+    process.env.APOS_RELEASE_ID = new Date().toLocaleDateString().replace(/\//g, '-');
 
     try {
-      await apos.asset.tasks.build.task();
+      await apos.asset.tasks.build.task({
+        'check-apos-build': true
+      });
     } catch (error) {
       // Do nothing
     }
     let releaseId = await releasePath();
-    let checkProdBuild = await checkFileExists(releaseId);
+    let checkProdBuild = await fs.pathExists(path.resolve(bundleDir, '..', releaseId));
     expect(checkProdBuild).toBe(true);
   });
 });

--- a/tests/test-override.test.js
+++ b/tests/test-override.test.js
@@ -5,7 +5,7 @@ const {
 } = require('expect');
 const _ = require('lodash');
 
-describe('Custom Code Editor : Override Options and Push Asset Test', function () {
+describe('Custom Code Editor : Override Options Test', function () {
   let originalOptionsTypes = require('../aceTypes');
   let apos;
 

--- a/tests/test-route.test.js
+++ b/tests/test-route.test.js
@@ -5,7 +5,7 @@ const {
 } = require('expect');
 const _ = require('lodash');
 
-describe('Custom Code Editor : Routes Saving Options', function () {
+describe('Custom Code Editor : Routes GET/POST/DELETE Options', function () {
 
   let dummyUser, apos, jar, token;
   let body = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,21 +2,24 @@
     "compilerOptions": {
         "allowJs": true,
         "module": "ES6",
+        "jsx": "preserve",
         "declaration": true,
         "noImplicitAny": true,
         "lib": [
             "es2019"
         ],
-        "outDir": "ui"
+        "outDir": "."
     },
     "exclude": [
         "node_modules",
         "public",
+        "./apostrophe/test-lib/test.js",
         ".stylelintrc"
     ],
     "include": [
         "./tests/**/*.js",
-        "ui/apos/**/*.js",
+        "./ui/apos/**/*.js",
+        "./ui/apos/**/*.vue",
         "./lib/**/*.js",
         "index.js"
     ]

--- a/ui/apos/components/CustomCodeEditor.vue
+++ b/ui/apos/components/CustomCodeEditor.vue
@@ -88,8 +88,8 @@
     import ChevronDeleteIcon from 'vue-material-design-icons/Delete.vue';
     import ChevronDropdownIcon from 'vue-material-design-icons/ChevronDown.vue';
     import ChevronDropupIcon from 'vue-material-design-icons/ChevronUp.vue';
-    import OptionsContainerComponent from './OptionsContainer.vue';
-    import CustomCodeEditorMixinVue from '../mixins/CustomCodeEditorMixin.js';
+    import OptionsContainerComponent from 'custom-code-editor-a3/components/OptionsContainer.vue';
+    import CustomCodeEditorMixinVue from 'custom-code-editor-a3/mixins/CustomCodeEditorMixin.js';
 
     // Import lodash
     import _ from 'lodash';
@@ -98,7 +98,31 @@
     import 'ace-builds';
     
     // Just use dynamic imports from webpack resolver. Let apostrophe compile acejs builds into its own folder by using webpack-merge
-    import 'ace-builds/webpack-resolver';
+    if (browserOptions.mode === 'development') {
+        import('ace-builds/webpack-resolver');
+    } else {
+        // Push All Ace files if true
+        if (_.has(browserOptions.ace, 'scripts.pushAllAce')){
+            // Import All Modes
+            for (let allModes = 0; allModes < browserOptions.ace._allModes.length; allModes++) {
+                import(`ace-builds/src-noconflict/mode-${browserOptions.ace._allModes[allModes]}.js`);
+                import(`ace-builds/src-noconflict/snippets/${browserOptions.ace._allModes[allModes]}.js`);
+            }
+            // Import All Themes
+            for (let allThemes = 0; allThemes < browserOptions.ace._allThemes.length; allThemes++) {
+                import(`ace-builds/src-noconflict/theme-${browserOptions.ace._allThemes[allThemes]}.js`);
+            }
+        } else {
+            // Dynamic Import Modes, Themes, and Snippets that are defined by your module
+            for (let i = 0; i < browserOptions.ace.modes.length; i++) {
+                import(`ace-builds/src-noconflict/mode-${browserOptions.ace.modes[i].name}`)
+                    .catch((e) => console.warn(`Unable to use mode for: '${browserOptions.ace.modes[i].name}''. Please make sure you use the correct mode names defined by 'Ace' Module`));
+                import(`ace-builds/src-noconflict/snippets/${browserOptions.ace.modes[i].name}`).catch((e) => null);
+            };
+            // Import just One Theme
+            import(`ace-builds/src-noconflict/theme-${browserOptions.ace.theme}.js`);
+        }
+    }
 
     // Solve beautify problem
     for(let i = 0; i < apos.customCodeEditor.browser.ace._otherFiles.length; i++) {

--- a/ui/apos/components/CustomCodeEditor.vue
+++ b/ui/apos/components/CustomCodeEditor.vue
@@ -7,7 +7,7 @@
                     <div class="editor-container">
                         <div class="dropdown" v-if="checkDropdown">
                             <button class="button-dropdown result" @click="dropdownClick = !dropdownClick">
-                                <component :is="dropdownComponentSwitch" /><span
+                                <component :is="dropdownComponentSwitch" :fill-color="checkDropdownColor" /><span
                                     class="dropdown-title">{{ getTitle }}</span></button>
                             <div class="dropdown-content" v-show="dropdownClick">
                                 <input type="text" placeholder="Search.." class="my-input" @keyup.stop="filterModesList"/>
@@ -28,7 +28,7 @@
                         </div>
                         <div v-if="checkOptionsCustomizer"
                             class="options-config">
-                            <button class="button-options" title="Adjust Options" @click="optionsClick = !optionsClick">
+                            <button class="button-options" title="Adjust Options" :style="optionsClick ? 'background: rgba(248, 248, 248, 1);' : '' " @click="optionsClick = !optionsClick">
                                 <ChevronGearIcon :size="16" />
                             </button>
                             <div class="options-container" v-show="optionsClick" @scroll="optionsScroll">
@@ -254,11 +254,9 @@
              */
             checkOptionsCustomizer() {
                 let condition = true;
-
                 if (_.has(this.ace, 'config.optionsCustomizer.enable')) {
                     condition = this.ace.config.optionsCustomizer.enable;
                 }
-
                 return condition;
             },
             /**
@@ -276,6 +274,16 @@
                     return 'ChevronDropupIcon';
                 } else {
                     return 'ChevronDropdownIcon';
+                }
+            },
+            /**
+             * @computed {String} checkDropdownColor Arrow Color for Dropdown Config
+             */
+            checkDropdownColor() {
+                if (_.has(this.ace.config, 'dropdown.arrowColor')) {
+                    return this.ace.config.dropdown.arrowColor;
+                } else {
+                    return ''
                 }
             },
             /**
@@ -307,7 +315,7 @@
                         })(i, this);
                     });
                 }
-
+                
                 return title;
             }
         },
@@ -400,7 +408,7 @@
                 const getIndex = _.findIndex(this.ace.optionsTypes[category], (val) => {
                     return val.name === name;
                 });
-
+                
                 if(getIndex !== -1) {
                     const cloneObject = _.cloneDeep(this.ace.optionsTypes[category][getIndex]);
 
@@ -426,5 +434,5 @@
 </script>
 
 <style lang="scss" scoped>
-    @import "../../src/editor.scss";
+    @import "custom-code-editor-a3/style/editor.scss";
 </style>

--- a/ui/apos/components/CustomCodeEditor.vue
+++ b/ui/apos/components/CustomCodeEditor.vue
@@ -327,6 +327,26 @@
             if (_.has(this.ace, 'config.optionsCustomizer.enable')) {
                 this.destroyClipboard();
             }
+
+            // Safe delete on `fieldAce`
+            if (_.has(apos.customCodeEditor.browser, `fieldAce.${this.field.name}`)) {
+                delete apos.customCodeEditor.browser.fieldAce[this.field.name];
+
+                // Safe delete after all this component initialized is remove
+                if (Object.keys(apos.customCodeEditor.browser.fieldAce).length === 0) {
+                    delete apos.customCodeEditor.browser.fieldAce;
+                }
+            }
+
+            // Safe delete on editor object
+            if (_.has(apos.customCodeEditor.browser, `editor.${this.field.name}`)) {
+                delete apos.customCodeEditor.browser.editor[this.field.name];
+
+                // Safe delete after all this component initialized is remove
+                if (Object.keys(apos.customCodeEditor.browser.editor).length === 0) {
+                    delete apos.customCodeEditor.browser.editor;
+                }
+            }
         },
         methods: {
 

--- a/ui/apos/components/OptionsContainer.vue
+++ b/ui/apos/components/OptionsContainer.vue
@@ -1156,7 +1156,7 @@
 
 
 <style lang="scss" scoped>
-    @import "../../src/index.scss";
+    @import "custom-code-editor-a3/style/index.scss";
 
     .label-text {
         color: $dim-gray;

--- a/ui/apos/components/OptionsContainer.vue
+++ b/ui/apos/components/OptionsContainer.vue
@@ -6,10 +6,10 @@
 
     /**
      * @typedef optionsTypes
-     * @prop {String} name
-     * @prop {String} type
-     * @prop {Object[] | Object | String | Null} value
-     * @prop {String} category
+     * @prop {String} name - Options Name
+     * @prop {String | Array} type - Options Types either that accept string value of `string`, `number` and/or `boolean`
+     * @prop {Object[] | Array | Object | String | Null} value - Default value of options
+     * @prop {String} category - Category of options
      */
 
     /**
@@ -977,6 +977,7 @@
                          * // This function emits on input type `select`
                          * this.$root.$emit('customCodeEditor:getOptions', {
                          * customCodeEditor: {
+                         *          field: this.$parent.field.name,
                          *          input: input,
                          *          name: input.name,
                          *          value: value.toString(),
@@ -1007,6 +1008,7 @@
                          * // This function emits on input type `range`
                          * this.$root.$emit('customCodeEditor:getOptions', {
                          * customCodeEditor: {
+                         *          field: this.$parent.field.name,
                          *          input: input,
                          *          name: input.name,
                          *          value: parseFloat(input.value),
@@ -1037,6 +1039,7 @@
                          * // This function emits on input type `checkbox`
                          * this.$root.$emit('customCodeEditor:getOptions', {
                          * customCodeEditor: {
+                         *          field: this.$parent.field.name,
                          *          input: input,
                          *          name: input.name,
                          *          value: input.checked,

--- a/ui/apos/components/OptionsContainer.vue
+++ b/ui/apos/components/OptionsContainer.vue
@@ -737,18 +737,18 @@
 
                             let checked = null;
                             if (!_.isUndefined(object.saveValue)) {
-                                checked = !checked;
+                                checked = object.saveValue;
                                 editor.setOption(object.name, object.saveValue);
                             } else if (_.isUndefined(object.saveValue)) {
                                 editor.getOptions()[object.name] ? checked = editor.getOptions()[object.name] : null;
                             }
 
-                            // Create <select> element
+                            // Create <checkbox> element
                             let input = h('input', {
                                 domProps: {
-                                    checked,
                                     type: 'checkbox',
                                     name: object.name,
+                                    checked: checked,
                                 },
                                 class: 'error',
                                 on: {
@@ -807,10 +807,6 @@
              * @return {Vue.VNode} Returns <ul> element that are grouped all the lists in the children
              */
             loopOptions(myOptions, h) {
-                if (Object.keys(this.originalOptions).length === 0) {
-                    this.originalOptions = _.cloneDeep(this.editor.getOptions())
-                }
-
                 let editor = this.editor;
                 let self = this;
                 // Create new <ul> element to group all lists in its children
@@ -993,6 +989,7 @@
                          */
                         this.$root.$emit('customCodeEditor:getOptions', {
                             customCodeEditor: {
+                                field: this.$parent.field.name,
                                 input: input,
                                 name: input.name,
                                 value: value.toString(),
@@ -1022,6 +1019,7 @@
                          */
                         this.$root.$emit('customCodeEditor:getOptions', {
                             customCodeEditor: {
+                                field: this.$parent.field.name,
                                 input: input,
                                 name: input.name,
                                 value: parseFloat(input.value),
@@ -1051,6 +1049,7 @@
                          */
                         this.$root.$emit('customCodeEditor:getOptions', {
                             customCodeEditor: {
+                                field: this.$parent.field.name,
                                 input: input,
                                 name: input.name,
                                 value: input.checked,
@@ -1070,7 +1069,7 @@
              * @fires component:OptionsContainerComponent~customCodeEditor:getOptions
              */
             updateOptions(e){
-                if(e.customCodeEditor && !_.isUndefined(e.customCodeEditor.value)) {
+                if(!_.isUndefined(e.customCodeEditor) && !_.isUndefined(e.customCodeEditor.value) && e.customCodeEditor.field !== this.$parent.field.name) {
                     // Find input from this current component
                     let input = this.$el.querySelector(`[name="${e.customCodeEditor.input.name}"]`);
 
@@ -1113,6 +1112,11 @@
         created(){
             this.getOptions()
                 .then((options) => {
+                    // Save to original Options first
+                    if (Object.keys(this.originalOptions).length === 0) {
+                        this.originalOptions = _.assign({}, _.cloneDeep(this.editor.getOptions()), _.isUndefined(apos.customCodeEditor.browser, `fieldAce.${this.$parent.field.name}`) ? !_.isUndefined(apos.customCodeEditor.browser.ace, 'options') ? apos.customCodeEditor.browser.ace.options : {} : !_.isUndefined(apos.customCodeEditor.browser.fieldAce[this.$parent.field.name], `options`) ? apos.customCodeEditor.browser.fieldAce[this.$parent.field.name].options : {})
+                    }
+
                     try {
                         if (options.status !== 'error') {
                             return JSON.parse(options.message);
@@ -1123,7 +1127,7 @@
                         throw new Error(e.message)
                     }
                 })
-                .then((result) => this.options = _.assign(this.options, result))
+                .then((result) => this.options = _.assign({}, this.options, result))
                 .then(() => this.$forceUpdate())
                 .catch((message) => {
                      apos.notify(message, {

--- a/ui/apos/mixins/CustomCodeEditorMixin.js
+++ b/ui/apos/mixins/CustomCodeEditorMixin.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import _ from 'lodash';
 import ClipboardJS from 'clipboard';
 
@@ -36,6 +35,7 @@ export default {
       editor.setValue('');
       editor.session.setMode(this.ace.aceModePath + this.ace.defaultMode.toLowerCase());
       editor.setTheme(this.ace.aceThemePath + this.ace.theme);
+      editor.setOption('enableEmmet', false);
 
       // Register Editor Events
       this.editorEvents.call(self, editor);
@@ -318,15 +318,12 @@ export default {
         // Clone to new object
         const cloneOptions = _.cloneDeep(apos.customCodeEditor.browser.ace);
 
-        // Remove existing browser ace options
-        delete apos.customCodeEditor.browser.ace;
-
         // Add with specific schema options
         apos.customCodeEditor.browser = {
           ...apos.customCodeEditor.browser,
-          ace: {
-            [this.field.name]: _.merge({}, cloneOptions, mergeOptions),
-            main: cloneOptions
+          // Store all merged that has override on schema level options into `fieldAce`.
+          fieldAce: {
+            [this.field.name]: _.merge({}, cloneOptions, mergeOptions)
           }
         };
       }

--- a/ui/apos/mixins/CustomCodeEditorMixin.js
+++ b/ui/apos/mixins/CustomCodeEditorMixin.js
@@ -35,6 +35,9 @@ export default {
       editor.setValue('');
       editor.session.setMode(this.ace.aceModePath + this.ace.defaultMode.toLowerCase());
       editor.setTheme(this.ace.aceThemePath + this.ace.theme);
+      if (apos.customCodeEditor.browser.mode === 'production') {
+        editor.setOption('useWorker', false);
+      }
       editor.setOption('enableEmmet', false);
 
       // Register Editor Events
@@ -196,9 +199,7 @@ export default {
           this.$el.querySelector('.dropdown-title').innerText = this.next.type.length > 0 ? this.next.type : self.ace.defaultMode;
 
           if (self.ace.modes[i].snippet && !self.ace.modes[i].disableSnippet) {
-
-            // eslint-disable-next-line no-undef
-            const beautify = ace.require('ace/ext/beautify');
+            let beautify = ace.require('ace/ext/beautify');
             editor.session.setValue(self.ace.modes[i].snippet);
             beautify.beautify(editor.session);
             // Find the template for replace the code area
@@ -406,7 +407,7 @@ export default {
               return;
             }
 
-            const beautify = ace.require('ace/ext/beautify');
+            let beautify = ace.require('ace/ext/beautify');
             editor.session.setValue(this.ace.modes[i].snippet);
             beautify.beautify(editor.session);
             // If changing mode got existing codes , replace the value

--- a/ui/src/editor.scss
+++ b/ui/src/editor.scss
@@ -1,4 +1,4 @@
-@import "index.scss";
+@import "custom-code-editor-a3/style/index.scss";
 
 // Code Editor
 .editor-container {
@@ -161,12 +161,13 @@
 
 .button-options {
     border: 0;
-    background-color: $white-smoke-3;
+    background-color: $white-smoke-3-blur-opac;
     box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
     width: 35px;
     height: 50px;
     border-radius: 0 0 0 15px;
     cursor: pointer;
+    backdrop-filter: blur(0.8px);
 
     &:hover {
         background-color: $gainsboro;

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -18,6 +18,7 @@ $white: rgba(255, 255, 255, 1);
 $white-smoke: rgba(239, 239, 239, 1);
 $white-smoke-2: rgba(240, 240, 240, 1);
 $white-smoke-3: rgba(248, 248, 248, 1);
+$white-smoke-3-blur-opac: rgba(248, 248, 248, 0.2);
 $dropdownHeight: 35px;
 $dropdownRadius: 5px;
 


### PR DESCRIPTION
Checklist:
- [x] Add alias resolve webpack for better module calling
- [x] Add merge config similar functionality to custom-code-editor
- [x] Add new computed properties for `arrowColor`
- [x] Readjust `setDefaultSubmitValue` call
- [x] Add `configDropdown` functions
- [x] Remove anything in afterInit so that user can override extends method easily
- [x] Adjust `saveCommand` functionality
- [x] Forgot to add dropdown title on first initialised
- [x] Adjust `setEditor` & `getEditor`
- [x] Fix `mergeConfig` bug on `apos.customCodeEditor.browser.ace` because Vue template is highly dependant on `apos.customCodeEditor.browser.ace` object
- [x] Fix `updateOptions` to only runs on specific field name
- [x] GIF Preview for Markdown
    - [x] Custom Code Editor A3 GIF
    - [x] Search Bar GIF
    - [x] Save Selection GIF
    - [x] Options Customizer
        - [x] Copy Options
        - [x] Undo Options
        - [x] Save Options
        - [x] Reset Options