### PR TITLE
Hotfixes 2.0.1 for better documentation & tests runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.0.1
 - Update tests better according to current webpack solution.
-- Update move ace production directories using `self.apos.rootDir`.
+- Update README for better documentation on how to add more methods.
 
 ### 2.0.0
 - Update packages & README.md (Thanks to @BoDonkey - https://github.com/BoDonkey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+### 2.0.1
+- Update tests better according to current webpack solution.
+- Update move ace production directories using `self.apos.rootDir`.
+
 ### 2.0.0
-- Update packages & README.md
-- Able to extend APOS UI on `afterInit` & `beforeInit` methods by overriding the file names inside 'apos-build' directories
+- Update packages & README.md (Thanks to @BoDonkey - https://github.com/BoDonkey)
+- Able to extend APOS UI on `afterInit` & `beforeInit` methods by overriding the file names inside 'modules/custom-code-editor-a3/ui/apos/mixins' directories
 - Move production files that were generated for Ace-Builds sourcemap files using handlers method on event `apostrophe:ready`. Only works if the user is running `build` || `release` script. (Temporary Solution until Apostrophe fix/update the issue).
 - Using `magic comments` on renaming chunk files on development modes.
 

--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ Simple , you can access it via `this.ace` in `AfterInit.js` that you had overrid
 # Changelog
 ### 2.0.1
 - Update tests better according to current webpack solution.
-- Update move ace production directories using `self.apos.rootDir`.
+- Update README for better documentation on how to add more methods.
 
 ### 2.0.0
 - Update packages & README.md (Thanks to @BoDonkey - https://github.com/BoDonkey)

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ By default we only push asset that are defined modes. It detect by your modes na
 
 Let say you want to add MORE commands that are already refered to [Ace Editor HOW TO](https://ace.c9.io/#nav=howto) or maybe add new events by yourself. First, let's create new js file to any name you like and push like this:
 
-Inside `AfterInit.js` :
+Inside **`modules/custom-code-editor-a3/ui/apos/mixins/AfterInit.js`** :
 ```js
 // In modules/custom-code-editor-a3/ui/apos/mixins/AfterInit.js
 export default {
@@ -604,8 +604,9 @@ export default {
 };
 ```
 
-Inside `BeforeInit.js`:
+Inside **`modules/custom-code-editor-a3/ui/apos/mixins/BeforeInit.js`**:
 ```js
+// In modules/custom-code-editor-a3/ui/apos/mixins/BeforeInit.js
 export default {
   methods: {
     beforeInit(element) {
@@ -681,9 +682,13 @@ Simple , you can access it via `this.ace` in `AfterInit.js` that you had overrid
 [Custom Code Editor Methods](https://ammein.github.io/custom-code-editor-a3/)
 
 # Changelog
+### 2.0.1
+- Update tests better according to current webpack solution.
+- Update move ace production directories using `self.apos.rootDir`.
+
 ### 2.0.0
-- Update packages & README.md
-- Able to extend APOS UI on `afterInit` & `beforeInit` methods by overriding the file names inside 'apos-build' directories
+- Update packages & README.md (Thanks to @BoDonkey - https://github.com/BoDonkey)
+- Able to extend APOS UI on `afterInit` & `beforeInit` methods by overriding the file names inside 'modules/custom-code-editor-a3/ui/apos/mixins' directories
 - Move production files that were generated for Ace-Builds sourcemap files using handlers method on event `apostrophe:ready`. Only works if the user is running `build` || `release` script. (Temporary Solution until Apostrophe fix/update the issue).
 - Using `magic comments` on renaming chunk files on development modes.
 

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = {
             // Something wrong on apostrophe that does not move ace-builds onto release directory.
             // Use copy plugin until Apostrophe came up with solution or fixes.
             try {
-              await move(path.join(path.join(self.apos.rootDir, 'public/apos-frontend/**/[0-9]*.apos-*')), path.join(path.join(self.apos.rootDir, 'public/apos-frontend/releases/' + self.apos.asset.getReleaseId() + '/' + self.apos.asset.getNamespace() + '/')));
+              await move(path.join(path.join(process.cwd(), 'public/apos-frontend/**/[0-9]*.apos-*')), path.join(path.join(process.cwd(), 'public/apos-frontend/releases/' + self.apos.asset.getReleaseId() + '/' + self.apos.asset.getNamespace() + '/')));
             } catch (e) {
               console.log('Unable to move Ace files to production folder', e);
             }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = {
             // Something wrong on apostrophe that does not move ace-builds onto release directory.
             // Use copy plugin until Apostrophe came up with solution or fixes.
             try {
-              await move(path.join(path.join(process.cwd(), 'public/apos-frontend/**/[0-9]*.apos-*')), path.join(path.join(process.cwd(), 'public/apos-frontend/releases/' + self.apos.asset.getReleaseId() + '/' + self.apos.asset.getNamespace() + '/')));
+              await move(path.join(path.join(self.apos.rootDir, 'public/apos-frontend/**/[0-9]*.apos-*')), path.join(path.join(self.apos.rootDir, 'public/apos-frontend/releases/' + self.apos.asset.getReleaseId() + '/' + self.apos.asset.getNamespace() + '/')));
             } catch (e) {
               console.log('Unable to move Ace files to production folder', e);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-code-editor-a3",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "ApostropheCMS version 3 Code Schema Field",
   "main": "index.js",
   "homepage": "https://ammein.github.io/custom-code-editor-a3/",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "deploy-page": "npm run jsdoc && gh-pages -d docs"
   },
   "dependencies": {
-    "ace-builds": "^1.23.4",
+    "ace-builds": "^1.24.0",
     "clean-webpack-plugin": "^4.0.0",
     "clipboard": "^2.0.11",
     "glob-move": "^1.0.1",
@@ -38,7 +38,7 @@
   "license": "ISC",
   "devDependencies": {
     "apostrophe": "^3.53.0",
-    "eslint": "^8.46.0",
+    "eslint": "^8.47.0",
     "eslint-config-punkave": "^2.1.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.28.0",
@@ -46,10 +46,10 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-standard": "^4.1.0",
-    "eslint-plugin-vue": "^9.16.1",
+    "eslint-plugin-vue": "^9.17.0",
     "expect": "^29.6.2",
     "fs-extra": "^11.1.1",
-    "gh-pages": "^5.0.0",
+    "gh-pages": "^6.0.0",
     "glob": "^10.3.3",
     "jsdoc": "^4.0.2",
     "jsdoc-vue": "^1.0.0",

--- a/tests/test-asset.test.js
+++ b/tests/test-asset.test.js
@@ -28,14 +28,16 @@ describe('Custom Code Editor : Clear Modes and Push All Assets', function () {
     return testUtil.destroy(apos);
   });
 
+  afterEach(async function() {
+    process.env.NODE_ENV = 'development';
+  });
+
   this.timeout(5 * 60 * 1000);
 
   it('should be a property of the apos object', async function () {
-    process.env.NODE_ENV = 'development';
     apos = await testUtil.create({
       // Make it `module` to be enabled because we have pushAssets method called
       root: module,
-      testModule: true,
       baseUrl: 'http://localhost:7990',
       modules: {
         'apostrophe-express': {
@@ -66,11 +68,9 @@ describe('Custom Code Editor : Clear Modes and Push All Assets', function () {
   });
 
   it('should build assets folder', async function () {
-    try {
-      await apos.asset.tasks.build.task();
-    } catch (err) {
-      console.log(err);
-    }
+    process.env.NODE_ENV = 'development';
+
+    await apos.asset.tasks.build.task();
 
     // Read All the Files that shows available mode
     let aceBuildsExists = await checkFileExists(path.join(namespace, 'ace-builds'));
@@ -127,9 +127,7 @@ describe('Custom Code Editor : Clear Modes and Push All Assets', function () {
   });
 
   it('should create new apos with production build', async function () {
-    process.env.NODE_ENV = 'production';
     await testUtil.destroy(apos);
-
     apos = await testUtil.create({
       // Make it `module` to be enabled because we have pushAssets method called
       root: module,
@@ -148,25 +146,11 @@ describe('Custom Code Editor : Clear Modes and Push All Assets', function () {
           handlers(self) {
             return {
               'apostrophe:afterInit': {
-                checkCustomCodeEditor() {
+                async checkCustomCodeEditor() {
                   namespace = self.apos.asset.getNamespace();
                   bundleDir = path.join(self.apos.rootDir, 'public', 'apos-frontend', namespace);
                   assert(self.apos.schema);
                   assert(self.apos.modules['custom-code-editor-a3']);
-                }
-              },
-              'apostrophe:ready': {
-                async moveAce() {
-                  if (self.apos.isTask()) {
-                    // A hacky solution to move chunk files from Ace Builds to Production directory.
-                    // Something wrong on apostrophe that does not move ace-builds onto release directory.
-                    // Use copy plugin until Apostrophe came up with solution or fixes.
-                    try {
-                      await move(path.join(path.join(process.cwd(), 'public/apos-frontend/**/[0-9]*.apos-*')), path.join(path.join(process.cwd(), 'public/apos-frontend/releases/' + self.apos.asset.getReleaseId() + '/' + self.apos.asset.getNamespace() + '/')));
-                    } catch (e) {
-                      console.log('Unable to move Ace files to production folder', e);
-                    }
-                  }
                 }
               }
             };
@@ -177,16 +161,19 @@ describe('Custom Code Editor : Clear Modes and Push All Assets', function () {
   });
 
   it('should generates all assets from custom-code-editor module from production modes', async function () {
+    await deleteBuiltFolders(publicFolderPath, true);
     process.env.APOS_RELEASE_ID = new Date().toLocaleDateString().replace(/\//g, '-');
+    process.env.NODE_ENV = 'production';
+    await apos.asset.tasks.build.task();
 
+    // Temporary solution for production releases
     try {
-      await apos.asset.tasks.build.task({
-        'check-apos-build': true
-      });
-    } catch (error) {
-      // Do nothing
-      console.log('Error on generate all production modes assets', error);
+      await move(path.join(path.join(apos.rootDir, 'public/apos-frontend/**/[0-9]*.apos-*')), path.join(path.join(apos.rootDir, 'public/apos-frontend/releases/' + apos.asset.getReleaseId() + '/' + apos.asset.getNamespace() + '/')));
+    } catch (e) {
+      console.log('Unable to move Ace files to production folder', e);
     }
+
+    // Checks
     let releaseId = await releasePath();
     let checkProdBuild = await fs.pathExists(path.resolve(bundleDir, '..', releaseId));
     if (!checkProdBuild) {
@@ -199,6 +186,10 @@ describe('Custom Code Editor : Clear Modes and Push All Assets', function () {
       checkProdDir.forEach((val, i) => {
         console.log('Lists of directory in prod assets folder', i + '- ' + val);
       });
+    } else {
+      // Temporary Tests
+      let checkProdFiles = checkOtherFilesExists(path.join('/releases/', apos.asset.getReleaseId(), apos.asset.getNamespace(), '[0-9]*.apos-*'), '[\\/][0-9]*.apos-.*.[js,map]$');
+      assert(checkProdFiles === true, `Production files not found in '${path.join('/releases/', apos.asset.getReleaseId(), apos.asset.getNamespace())}'`);
     }
     expect(checkProdBuild).toBe(true);
   });

--- a/tests/test-asset.test.js
+++ b/tests/test-asset.test.js
@@ -38,6 +38,7 @@ describe('Custom Code Editor : Clear Modes and Push All Assets', function () {
     apos = await testUtil.create({
       // Make it `module` to be enabled because we have pushAssets method called
       root: module,
+      testModule: true,
       baseUrl: 'http://localhost:7990',
       modules: {
         'apostrophe-express': {


### PR DESCRIPTION
- Update tests better according to the current webpack solution.
- Update move ace production directories using `self.apos.rootDir`.
- Update documentation on how to add ace methods using `afterInit` and `beforeInit`.